### PR TITLE
Update xenon-core.css

### DIFF
--- a/assets/css/xenon-core.css
+++ b/assets/css/xenon-core.css
@@ -1219,7 +1219,6 @@ body {
     }
     .sidebar-menu.collapsed .sidebar-menu-inner {
         overflow: visible;
-        position: relative
     }
     .sidebar-menu.collapsed .logo-env {
         padding: 18px 0


### PR DESCRIPTION
本次提交用来解决当左侧菜单收起时，左侧菜单栏会随着鼠标滚动而滚动，这里应该继承父级fixed属性，通过删除.sidebsidebar-menu-inner下的position: relative属性可以解决此问题